### PR TITLE
feat: add mockAssets.json with simulated gallery data

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,13 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {}
+const nextConfig = {
+     images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "picsum.photos",
+      },
+    ],
+  },
+}
 
 module.exports = nextConfig

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,22 @@
+import mockAssets from "@/data/mockAssets.json";
+import Image from "next/image";
+
 export default function Home() {
   return (
-    <main className="p-4">
-      {/* Gallery content will be rendered here */}
+    <main className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 p-4">
+      {mockAssets.map( ( asset ) => (
+        <div key={asset.id} className="rounded shadow bg-white p-2">
+          <Image
+            src={asset.thumbnail}
+            alt={asset.title}
+            width={600}
+            height={400}
+            className="rounded object-cover"
+          />
+          <h2 className="mt-2 text-sm font-semibold">{asset.title}</h2>
+          <p className="text-xs text-gray-500">{asset.boardName}</p>
+        </div>
+      ) )}
     </main>
   );
 }

--- a/src/data/mockAssets.json
+++ b/src/data/mockAssets.json
@@ -1,0 +1,82 @@
+[
+    {
+        "id": "1",
+        "title": "Brand Guidelines",
+        "thumbnail": "https://picsum.photos/seed/brand-guidelines/600/400",
+        "boardName": "Marketing",
+        "description": "Assets related to branding, tone, and design standards.",
+        "createdAt": "2024-12-01T10:00:00Z"
+    },
+    {
+        "id": "2",
+        "title": "Team Introductions",
+        "thumbnail": "https://picsum.photos/seed/team-intros/600/400",
+        "boardName": "People Ops",
+        "description": "Meet our internal team with headshots and short bios.",
+        "createdAt": "2024-12-02T12:00:00Z"
+    },
+    {
+        "id": "3",
+        "title": "Product Concepts",
+        "thumbnail": "https://picsum.photos/seed/product-preview/600/400",
+        "boardName": "Product",
+        "description": "Early previews of product features and user flows.",
+        "createdAt": "2024-12-03T14:00:00Z"
+    },
+    {
+        "id": "4",
+        "title": "Event Footage",
+        "thumbnail": "https://picsum.photos/seed/fall-gala/600/400",
+        "boardName": "Events",
+        "description": "Photos and clips from our latest in-person meetups.",
+        "createdAt": "2024-12-04T16:00:00Z"
+    },
+    {
+        "id": "5",
+        "title": "Packaging Drafts",
+        "thumbnail": "https://picsum.photos/seed/packaging/600/400",
+        "boardName": "Design",
+        "description": "Mockups for packaging and physical product presentation.",
+        "createdAt": "2024-12-05T18:00:00Z"
+    },
+    {
+        "id": "6",
+        "title": "Customer Testimonials",
+        "thumbnail": "https://picsum.photos/seed/testimonials/600/400",
+        "boardName": "Customer Success",
+        "description": "Clips and quotes from real customers using our product.",
+        "createdAt": "2024-12-06T20:00:00Z"
+    },
+    {
+        "id": "7",
+        "title": "Press Kit Assets",
+        "thumbnail": "https://picsum.photos/seed/presskit/600/400",
+        "boardName": "Marketing",
+        "description": "Images and messaging used in recent press releases.",
+        "createdAt": "2024-12-07T09:00:00Z"
+    },
+    {
+        "id": "8",
+        "title": "UI Exploration",
+        "thumbnail": "https://picsum.photos/seed/uiexploration/600/400",
+        "boardName": "Product Design",
+        "description": "Concepts for future interface enhancements.",
+        "createdAt": "2024-12-08T11:00:00Z"
+    },
+    {
+        "id": "9",
+        "title": "Social Media Templates",
+        "thumbnail": "https://picsum.photos/seed/socialposts/600/400",
+        "boardName": "Social",
+        "description": "Prebuilt Figma or Canva templates for social sharing.",
+        "createdAt": "2024-12-09T13:00:00Z"
+    },
+    {
+        "id": "10",
+        "title": "Campaign Slides",
+        "thumbnail": "https://picsum.photos/seed/adcampaign/600/400",
+        "boardName": "Growth",
+        "description": "Visual assets from the latest paid campaign deck.",
+        "createdAt": "2024-12-10T15:00:00Z"
+    }
+]


### PR DESCRIPTION
Summary
Created mock asset data for the gallery layout using realistic structure modeled after Air's boards.ts and clips.ts files. This simulates a creative workflow with board references, image thumbnails, and relevant metadata.

Changes Made

- Created src/data/mockAssets.json
- Included 10 records using https://picsum.photos/seed/... for random but stable image thumbnails

Shaped each item with:

- id
- title
- thumbnail
- boardName
- description
- createdAt

Reasoning
A robust and believable dataset is key to rendering a realistic board UI while keeping everything local and fast. This mock dataset enables testing layout, image rendering, and infinite scroll behavior without depending on live APIs.

Acceptance Criteria
-  File is located at src/data/mockAssets.json
-  Data is shaped using Air-like structures
-  All thumbnail links are accessible and display correctly

Screenshot
<img width="1690" alt="Screenshot 2025-04-12 at 10 58 59 AM" src="https://github.com/user-attachments/assets/9aa5fe8b-8d56-499f-8410-0127656df448" />


Related Issue
Closes #3 