### PR TITLE
feat: build BoardCard component & render gallery layout using mock data

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,32 @@
+# Summary
+
+_What is this pull request doing? Briefly explain the purpose and scope._
+
+# Changes Made
+
+- Bullet-point summary of key changes or features added
+- Highlight any file moves, structural changes, or utilities created
+- If styling or performance improvements were included, list them here
+
+# Reasoning
+
+_Why were these changes made? What problem does this solve or what goal does it fulfill?_
+
+# Acceptance Criteria
+
+- [ ] Feature/component is working as intended
+- [ ] Data is correctly rendered or passed
+- [ ] Styling and spacing match the expected layout
+- [ ] No new linting or runtime errors
+
+# Screenshots
+
+_Add screenshots or screen recordings of the component, layout, or feature._
+
+# Related Issue
+
+Closes #
+
+# Notes for Reviewers
+
+_Any additional notes, blockers, edge cases, or follow-up ideas._

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,21 +1,16 @@
 import mockAssets from "@/data/mockAssets.json";
-import Image from "next/image";
+import { BoardCard } from "@/components/BoardCard";
 
 export default function Home() {
   return (
     <main className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 p-4">
       {mockAssets.map( ( asset ) => (
-        <div key={asset.id} className="rounded shadow bg-white p-2">
-          <Image
-            src={asset.thumbnail}
-            alt={asset.title}
-            width={600}
-            height={400}
-            className="rounded object-cover"
-          />
-          <h2 className="mt-2 text-sm font-semibold">{asset.title}</h2>
-          <p className="text-xs text-gray-500">{asset.boardName}</p>
-        </div>
+        <BoardCard
+          key={asset.id}
+          title={asset.title}
+          thumbnail={asset.thumbnail}
+          boardName={asset.boardName}
+        />
       ) )}
     </main>
   );

--- a/src/components/BoardCard.tsx
+++ b/src/components/BoardCard.tsx
@@ -1,0 +1,26 @@
+import { ImageWithPlaceholder } from "./ImageWithPlaceholder";
+
+export interface IBoardCardProps {
+    title: string;
+    thumbnail: string;
+    boardName: string;
+}
+
+export const BoardCard = ( { title, thumbnail, boardName }: IBoardCardProps ) => {
+    return (
+        <div className="rounded-lg shadow-sm border bg-white hover:shadow-md transition duration-200 ease-in-out">
+            <div className="relative aspect-[3/2] w-full overflow-hidden rounded-t-lg">
+                <ImageWithPlaceholder
+                    src={thumbnail}
+                    alt={title}
+                    className="rounded-t-lg"
+                    priority={false}
+                />
+            </div>
+            <div className="p-3">
+                <h3 className="text-sm font-semibold truncate">{title}</h3>
+                <p className="text-xs text-gray-500">{boardName}</p>
+            </div>
+        </div>
+    );
+}

--- a/src/components/ImageWithPlaceholder.tsx
+++ b/src/components/ImageWithPlaceholder.tsx
@@ -1,0 +1,35 @@
+import Image from "next/image";
+
+interface IImageWithPlaceholderProps {
+    src: string;
+    alt: string;
+    width?: number;
+    height?: number;
+    className?: string;
+    priority?: boolean;
+    sizes?: string;
+}
+
+export const ImageWithPlaceholder = ( {
+    src,
+    alt,
+    width = 600,
+    height = 400,
+    className = "",
+    priority = false,
+    sizes = "(min-width: 1024px) 25vw, 50vw"
+}: IImageWithPlaceholderProps ) => {
+    return (
+        <Image
+            src={src}
+            alt={alt}
+            width={width}
+            height={height}
+            className={`object-cover ${ className }`}
+            placeholder="blur"
+            blurDataURL="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0nMTAwJScgaGVpZ2h0PSc1MCUnIHhtbG5zPSdodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2Zyc+PHJlY3Qgd2lkdGg9JzEwMCUnIGhlaWdodD0nNTAlJyBmaWxsPSIjZGRkZGRkIi8+PC9zdmc+"
+            priority={priority}
+            sizes={sizes}
+        />
+    );
+}


### PR DESCRIPTION
### Summary

Created the visual gallery layout using a new `BoardCard` component to render the mock asset data from `mockAssets.json`. The component displays a responsive grid of cards using Next.js Image optimization and Tailwind for styling.

---

### Changes Made

- Created `BoardCard.tsx` to display each asset with title, board name, and thumbnail
- Integrated `ImageWithPlaceholder.tsx` for optimized, blurred image loading
- Updated `page.tsx` to render the asset grid using the new card component
- Applied responsive grid layout with Tailwind classes

---

### Reasoning

This layout simulates the visual browsing experience used in creative tools like Air. Breaking out the card component ensures reusability and better structure as more interactivity or styling layers are added.

---

### Acceptance Criteria

- [x] BoardCard accepts `title`, `thumbnail`, `boardName` as props
- [x] Images are displayed with blurDataURL placeholders
- [x] Responsive grid layout works across screen sizes
- [x] Clean separation of structure and styling

---

### Screenshots

![Screenshot 2025-04-12 at 11-11-19 Air's Gallery Challenge](https://github.com/user-attachments/assets/74bd2c06-0021-4581-8006-fde0f69cad02)


---

### Related Issue

Closes #4 

---

### Notes for Reviewers

Image sizes are responsive and lazy-loaded to support scalability. Next step will wire in infinite scroll and optimize performance for larger sets of mock data.
