### PR TITLE
Add Accessibility Improvements for BoardCard and ClipCard

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,10 @@
-"use client"
-import { BoardSection } from "@/components/BoardSection";
+'use client'
+import { BoardSection } from '@/components/BoardSection'
 
 export default function Home() {
-  return (
-    <div className="p-6">
-        <BoardSection />
-    </div>
-  )
+    return (
+        <main className="p-6">
+            <BoardSection />
+        </main>
+    )
 }

--- a/src/components/BoardCard.tsx
+++ b/src/components/BoardCard.tsx
@@ -1,30 +1,36 @@
-import { ImageWithPlaceholder } from "./ImageWithPlaceholder";
+import { ImageWithPlaceholder } from './ImageWithPlaceholder'
 
 /**
  * BoardCard
- * 
+ *
  * A styled card component for displaying a creative asset or board item.
  * Renders an optimized image with title and board name.
- * 
+ *
  * Props:
  * @param title - the title of the asset or board
  * @param thumbnail - the image URL (can be external)
  */
 
 export interface IBoardCardProps {
-    title: string;
-    thumbnail?: string;
-    priority?: boolean;
-    loading?: "lazy" | "eager";
+    title: string
+    thumbnail?: string
+    priority?: boolean
+    loading?: 'lazy' | 'eager'
 }
 
-export const BoardCard = ( { title, thumbnail, priority, loading }: IBoardCardProps ) => {
-    const thumbnailUrl = thumbnail ?? 'https://picsum.photos/seed/team-intros/480/320'
+export const BoardCard = ({
+    title,
+    thumbnail,
+    priority,
+    loading,
+}: IBoardCardProps) => {
+    const thumbnailUrl =
+        thumbnail ?? 'https://picsum.photos/seed/team-intros/480/320'
     return (
         <div className="relative rounded-lg overflow-hidden shadow bg-white hover:shadow-md  transition-transform duration-200 ease-in-out border border-gray-200 aspect-square hover:scale-105">
             <ImageWithPlaceholder
                 src={thumbnailUrl}
-                alt={title}
+                alt={`Preview image for the ${title} board`}
                 className="object-cover w-full h-full"
                 priority={priority}
                 loading={loading}
@@ -32,8 +38,10 @@ export const BoardCard = ( { title, thumbnail, priority, loading }: IBoardCardPr
             />
 
             <div className="absolute bottom-0 left-0 w-full bg-gradient-to-t from-black/60 to-transparent px-3 py-2">
-                <p className="text-sm font-medium text-white truncate">{title}</p>
+                <p className="text-sm font-medium text-white truncate">
+                    {title}
+                </p>
             </div>
         </div>
-    );
+    )
 }

--- a/src/components/BoardSection.tsx
+++ b/src/components/BoardSection.tsx
@@ -58,9 +58,9 @@ export const BoardSection = () => {
     return (
         <>
             <section className="mb-6">
-                <h2 className="text-sm font-semibold text-gray-700 mb-2">
+                <h1 className="text-sm font-semibold text-gray-700 mb-2">
                     Boards ({boards.length})
-                </h2>
+                </h1>
                 {boardsLoading ? (
                     <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
                         {Array.from({ length: boards.length }).map((_, i) => (

--- a/src/components/ClipCard.tsx
+++ b/src/components/ClipCard.tsx
@@ -130,7 +130,13 @@ const ClipCard = ({ clip }: IClipCardProps) => {
         }
     }
     const width = clip.width > 800 ? 800 : clip.width || 400
-    const height = clip.height && clip.width ? Math.round((clip.height / clip.width) * (clip.width > 800 ? 800 : clip.width)) : 300
+    const height =
+        clip.height && clip.width
+            ? Math.round(
+                  (clip.height / clip.width) *
+                      (clip.width > 800 ? 800 : clip.width)
+              )
+            : 300
     return (
         <div className="rounded overflow-hidden shadow bg-white hover:shadow-lg transition-transform duration-200 ease-in-out hover:scale-105">
             {clip.type === 'photo' && (
@@ -144,9 +150,8 @@ const ClipCard = ({ clip }: IClipCardProps) => {
                             'object-cover w-full h-full',
                             isImageLoaded
                                 ? 'opacity-100'
-                                  : 'opacity-0 transition-opacity duration-500 ease-in-out'
+                                : 'opacity-0 transition-opacity duration-500 ease-in-out'
                         )}
-                        
                         sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
                         priority={false}
                         loading="lazy"
@@ -157,7 +162,7 @@ const ClipCard = ({ clip }: IClipCardProps) => {
                 </div>
             )}
 
-            {clip.type === "video" && (
+            {clip.type === 'video' && (
                 <div
                     data-testid="clip-card-video-wrapper"
                     className="relative aspect-video group overflow-hidden rounded-md group-hover:brightness-90 group-hover:scale-105 transition cursor-pointer"
@@ -172,6 +177,8 @@ const ClipCard = ({ clip }: IClipCardProps) => {
                         playsInline
                         preload="metadata"
                         controls={false}
+                        aria-hidden="true"
+                        tabIndex={-1}
                         data-testid="clip-video"
                         className="aspect-video object-cover rounded-md transition group-hover:brightness-90 group-hover:scale-105 w-full"
                     >


### PR DESCRIPTION
### Summary
This PR focuses on improving the accessibility of the gallery interface by addressing core accessibility recommendations outlined in the Lighthouse and WAVE audits.

### Changes Made

- Added `aria-hidden="true"` to the `<video>` elements in `ClipCard.tsx` to clarify that videos are silent and do not require captions
- Improved alt text logic for `BoardCard` images to avoid redundant or unhelpful alt text (`alt={title}` now provides a clearer description of the board)
- Added `tabIndex={-1}` to video components to avoid unnecessary tab stops
- Ensured color contrast passes WCAG minimum contrast thresholds across both cards
- Reviewed interactive elements to ensure keyboard accessibility and focus styles are retained via Tailwind

### Why It Matters
These updates improve the experience for screen reader users, keyboard navigators, and those with visual impairments, while also reducing noise from accessibility tooling.

### Next Steps / Future Considerations
- Explore use of `@axe-core/react` or similar tooling for continuous accessibility checks
- Consider adding captions or descriptive metadata for videos that include meaningful content or sound
- Review keyboard focus outlines for high visibility themes and accessibility consistency

### Screenshots
_N/A (visuals unchanged)_

### Related Issue
Closes #24

<img width="366" alt="Screenshot 2025-04-14 at 8 42 00 AM" src="https://github.com/user-attachments/assets/093436dc-b51a-4bfb-b630-79e7ea539130" />
<img width="374" alt="Screenshot 2025-04-14 at 9 16 20 AM" src="https://github.com/user-attachments/assets/ea480353-f5c4-427a-b022-eabde75316ec" />

